### PR TITLE
docs: document changelog rules and feature flags

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -25,6 +25,11 @@ outlined below.
 - Dynamic variables are wrapped in `{{curly_braces}}`.
 - Each prompt has its own page under `/docs/fr/prompts/` and `/docs/en/prompts/`.
 
+## Changelog
+- Record every change in `CHANGELOG.md` under the `[Unreleased]` section.
+- Categorise entries under **Added**, **Changed** and **Removed**.
+- Keep entries brief; you'll be told when to move them to a release section.
+
 ## Good practices
 1. **FR/EN coherence** – always update both languages.
 2. **Living glossary** – never forget to add new terms.
@@ -35,5 +40,6 @@ outlined below.
 7. **Comments and documentation** – use `///` doc comments for public items and inline comments for complex logic; include examples where helpful.
 8. **Formatting and linting** – run `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` before committing.
 9. **Testing** – provide unit, integration and doc tests; run `cargo test` and ensure all tests pass.
+10. **Feature flags** – gate unfinished or optional features behind Cargo feature flags (TBD) so they stay disabled until ready.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - 🌐 CORS origins configurable via `ALLOWED_ORIGINS` env var; disallowed origins return `403`
+- 📝 Documented changelog tracking and feature flag usage in `AGENT.md`
 
 ## [0.3.0] – 2025-08-02
 


### PR DESCRIPTION
## Summary
- clarify changelog management requirements in AGENT guidelines
- mention use of feature flags for WIP functionality

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689df9eef4008321bddc6af72c072e02