### PR TITLE
feat: abstract docker client

### DIFF
--- a/daemon/src/docker/container.rs
+++ b/daemon/src/docker/container.rs
@@ -1,144 +1,11 @@
 use std::{collections::HashMap, process::Command};
 
-use crate::errors::Error;
+use crate::{errors::Error, services::docker::DockerClient};
 
 use super::{
     models::{AppInstance, AppStatus},
     ContainerConfig,
 };
-
-/// Create and run a new Docker container using the `docker` CLI.
-///
-/// # Arguments
-/// - `cfg`: Configuration for the container, including name, image, ports, etc.
-///
-/// # Returns
-/// - `Ok(container_id)` on success
-/// - `Err(Error)` on failure
-pub fn create_and_run_container(cfg: ContainerConfig) -> Result<String, Error> {
-    let port = cfg.container_port;
-    let port_args: Vec<String> = cfg
-        .host_ports
-        .iter()
-        .flat_map(|host| vec!["-p".to_string(), format!("{host}:{port}")])
-        .collect();
-
-    let label_args: Vec<String> = cfg
-        .labels
-        .unwrap_or(&HashMap::new())
-        .iter()
-        .flat_map(|(k, v)| vec!["--label".to_string(), format!("{k}={v}")])
-        .collect();
-
-    let env_args: Vec<String> = cfg
-        .env
-        .unwrap_or(&HashMap::new())
-        .iter()
-        .flat_map(|(k, v)| vec!["-e".to_string(), format!("{k}={v}")])
-        .collect();
-
-    let volume_args: Vec<String> = cfg
-        .volumes
-        .unwrap_or(&vec![])
-        .iter()
-        .flat_map(|mount| vec!["-v".to_string(), mount.to_string()])
-        .collect();
-
-    if let Some(vols) = cfg.volumes {
-        for v in vols {
-            if !v.contains(':') || v.starts_with(':') || v.ends_with(':') {
-                return Err(Error::BadRequest(format!("Invalid volume format: '{v}'")));
-            }
-        }
-    }
-
-    if let Some(policy) = cfg.restart_policy {
-        let valid = ["no", "always", "on-failure", "unless-stopped"];
-        if !valid.contains(&policy) {
-            return Err(Error::InvalidRequest(format!(
-                "Invalid restart policy: '{policy}'"
-            )));
-        }
-    }
-
-    let mut args = vec!["run", "-d", "--rm", "--name", cfg.name];
-    args.extend(port_args.iter().map(String::as_str));
-    args.extend(label_args.iter().map(String::as_str));
-    args.extend(env_args.iter().map(String::as_str));
-    args.extend(volume_args.iter().map(String::as_str));
-
-    if let Some(policy) = cfg.restart_policy {
-        args.push("--restart");
-        args.push(policy);
-    }
-
-    args.push(cfg.image);
-
-    let output = Command::new("docker")
-        .args(&args)
-        .output()
-        .map_err(|_| Error::DockerCommandFailed)?;
-
-    if output.status.success() {
-        let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        Ok(container_id)
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        Err(Error::Unexpected(stderr.trim().to_string()))
-    }
-}
-
-/// Starts a stopped Docker container by name using `docker start`.
-///
-/// # Arguments
-/// - `name`: Name of the existing container.
-///
-/// # Returns
-/// - `Ok(())` if the container was started successfully.
-/// - `Err(Error)` if the container does not exist or Docker CLI fails.
-pub fn start_container(name: &str) -> Result<(), Error> {
-    let output = std::process::Command::new("docker")
-        .args(["start", name])
-        .output()
-        .map_err(|_| Error::DockerCommandFailed)?;
-
-    if output.status.success() {
-        Ok(())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
-        if stderr.contains("no such container") {
-            Err(Error::ContainerNotFound)
-        } else {
-            Err(Error::Unexpected(stderr.trim().to_string()))
-        }
-    }
-}
-
-/// Stops a running Docker container by name using `docker stop`.
-///
-/// # Arguments
-/// - `name`: Name of the running container.
-///
-/// # Returns
-/// - `Ok(())` if the container was stopped successfully.
-/// - `Err(Error)` if the container does not exist or Docker CLI fails.
-pub fn stop_container(name: &str) -> Result<(), Error> {
-    let output = std::process::Command::new("docker")
-        .args(["stop", name])
-        .output()
-        .map_err(|_| Error::DockerCommandFailed)?;
-
-    if output.status.success() {
-        Ok(())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
-        if stderr.contains("no such container") {
-            Err(Error::ContainerNotFound)
-        } else {
-            Err(Error::Unexpected(stderr.trim().to_string()))
-        }
-    }
-}
 
 /// Recreates a Docker container by name: stops, deletes, and restarts it with same config.
 ///
@@ -148,19 +15,10 @@ pub fn stop_container(name: &str) -> Result<(), Error> {
 /// # Returns
 /// - `Ok(container_id)` if successful
 /// - `Err(Error)` if failed
-pub fn recreate_container(name: &str) -> Result<String, Error> {
-    let output = std::process::Command::new("docker")
-        .args(["inspect", name])
-        .output()
-        .map_err(|_| Error::DockerCommandFailed)?;
-
-    if !output.status.success() {
-        return Err(Error::ContainerNotFound);
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
+pub fn recreate_container(client: &dyn DockerClient, name: &str) -> Result<String, Error> {
+    let output = client.inspect(name)?;
     let container: Vec<serde_json::Value> =
-        serde_json::from_str(&stdout).map_err(|e| Error::DockerOutputParse(e.to_string()))?;
+        serde_json::from_str(&output).map_err(|e| Error::DockerOutputParse(e.to_string()))?;
 
     if container.is_empty() {
         return Err(Error::ContainerNotFound);
@@ -193,7 +51,7 @@ pub fn recreate_container(name: &str) -> Result<String, Error> {
     let labels = cfg["Config"]["Labels"].as_object().map(|map| {
         map.iter()
             .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
-            .collect::<std::collections::HashMap<String, String>>()
+            .collect::<HashMap<String, String>>()
     });
 
     let env_vars = cfg["Config"]["Env"].as_array().map(|vars| {
@@ -205,7 +63,7 @@ pub fn recreate_container(name: &str) -> Result<String, Error> {
                 let v = split.next().unwrap_or("");
                 Some((k.to_string(), v.to_string()))
             })
-            .collect::<std::collections::HashMap<String, String>>()
+            .collect::<HashMap<String, String>>()
     });
 
     let volumes = cfg["HostConfig"]["Binds"].as_array().map(|items| {
@@ -215,14 +73,15 @@ pub fn recreate_container(name: &str) -> Result<String, Error> {
             .map(|s| s.to_string())
             .collect::<Vec<String>>()
     });
+
     let restart_policy = cfg["HostConfig"]["RestartPolicy"]["Name"]
         .as_str()
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
 
-    super::remove_container(name)?;
+    remove_container(name)?;
 
-    super::create_and_run_container(ContainerConfig {
+    client.run(ContainerConfig {
         name,
         image,
         host_ports: &host_ports,
@@ -286,20 +145,18 @@ pub fn get_running_containers() -> Result<Vec<AppInstance>, Error> {
 /// - `Ok(Some(AppInstance))` if found
 /// - `Ok(None)` if not found
 /// - `Err(Error)` if an error occurred
-pub fn get_container_by_name(name: &str) -> Result<Option<AppInstance>, Error> {
-    let output = Command::new("docker")
-        .args(["inspect", name])
-        .output()
-        .map_err(|_| Error::DockerCommandFailed)?;
-
-    if !output.status.success() {
-        return Ok(None);
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
+pub fn get_container_by_name(
+    client: &dyn DockerClient,
+    name: &str,
+) -> Result<Option<AppInstance>, Error> {
+    let output = match client.inspect(name) {
+        Ok(o) => o,
+        Err(Error::ContainerNotFound) => return Ok(None),
+        Err(e) => return Err(e),
+    };
 
     let containers: Vec<serde_json::Value> =
-        serde_json::from_str(&stdout).map_err(|e| Error::DockerOutputParse(e.to_string()))?;
+        serde_json::from_str(&output).map_err(|e| Error::DockerOutputParse(e.to_string()))?;
 
     if containers.is_empty() {
         return Ok(None);
@@ -351,17 +208,19 @@ pub fn get_container_by_name(name: &str) -> Result<Option<AppInstance>, Error> {
 /// # Returns
 /// - `Ok(status)` if found (e.g., "running", "exited", etc.)
 /// - `Err(ContainerNotFound)` if not found
-pub fn get_container_status(name: &str) -> Result<String, Error> {
-    let output = std::process::Command::new("docker")
-        .args(["inspect", name, "--format", "{{.State.Status}}"])
-        .output()
-        .map_err(|_| Error::DockerCommandFailed)?;
+pub fn get_container_status(client: &dyn DockerClient, name: &str) -> Result<String, Error> {
+    let output = client.inspect(name)?;
+    let containers: Vec<serde_json::Value> =
+        serde_json::from_str(&output).map_err(|e| Error::DockerOutputParse(e.to_string()))?;
 
-    if !output.status.success() {
+    if containers.is_empty() {
         return Err(Error::ContainerNotFound);
     }
 
-    let status = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let status = containers[0]["State"]["Status"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
     Ok(status)
 }
 

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -2,3 +2,4 @@ pub mod api;
 pub mod docker;
 pub mod errors;
 pub mod routes;
+pub mod services;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod docker;
 mod errors;
 mod routes;
+mod services;
 
 use api::routes::router;
 use std::net::SocketAddr;

--- a/daemon/src/services/docker.rs
+++ b/daemon/src/services/docker.rs
@@ -1,0 +1,151 @@
+use std::{collections::HashMap, process::Command};
+
+use crate::{docker::ContainerConfig, errors::Error};
+
+/// Abstraction over Docker interactions.
+///
+/// This trait exposes a minimal set of operations required by the
+/// application and allows for future alternative implementations
+/// (e.g. talking to a daemon over sockets or HTTP).
+pub trait DockerClient: Send + Sync + 'static {
+    /// Run a new container.
+    fn run(&self, cfg: ContainerConfig) -> Result<String, Error>;
+    /// Start an existing container.
+    fn start(&self, name: &str) -> Result<(), Error>;
+    /// Stop a running container.
+    fn stop(&self, name: &str) -> Result<(), Error>;
+    /// Inspect a container and return the raw JSON output.
+    fn inspect(&self, name: &str) -> Result<String, Error>;
+}
+
+/// Docker client backed by shelling out to the `docker` CLI.
+pub struct ShellDockerClient;
+
+impl DockerClient for ShellDockerClient {
+    fn run(&self, cfg: ContainerConfig) -> Result<String, Error> {
+        let port = cfg.container_port;
+        let port_args: Vec<String> = cfg
+            .host_ports
+            .iter()
+            .flat_map(|host| vec!["-p".to_string(), format!("{host}:{port}")])
+            .collect();
+
+        let label_args: Vec<String> = cfg
+            .labels
+            .unwrap_or(&HashMap::new())
+            .iter()
+            .flat_map(|(k, v)| vec!["--label".to_string(), format!("{k}={v}")])
+            .collect();
+
+        let env_args: Vec<String> = cfg
+            .env
+            .unwrap_or(&HashMap::new())
+            .iter()
+            .flat_map(|(k, v)| vec!["-e".to_string(), format!("{k}={v}")])
+            .collect();
+
+        let volume_args: Vec<String> = cfg
+            .volumes
+            .unwrap_or(&vec![])
+            .iter()
+            .flat_map(|mount| vec!["-v".to_string(), mount.to_string()])
+            .collect();
+
+        if let Some(vols) = cfg.volumes {
+            for v in vols {
+                if !v.contains(':') || v.starts_with(':') || v.ends_with(':') {
+                    return Err(Error::BadRequest(format!("Invalid volume format: '{v}'")));
+                }
+            }
+        }
+
+        if let Some(policy) = cfg.restart_policy {
+            let valid = ["no", "always", "on-failure", "unless-stopped"];
+            if !valid.contains(&policy) {
+                return Err(Error::InvalidRequest(format!(
+                    "Invalid restart policy: '{policy}'"
+                )));
+            }
+        }
+
+        let mut args = vec!["run", "-d", "--rm", "--name", cfg.name];
+        args.extend(port_args.iter().map(String::as_str));
+        args.extend(label_args.iter().map(String::as_str));
+        args.extend(env_args.iter().map(String::as_str));
+        args.extend(volume_args.iter().map(String::as_str));
+
+        if let Some(policy) = cfg.restart_policy {
+            args.push("--restart");
+            args.push(policy);
+        }
+
+        args.push(cfg.image);
+
+        let output = Command::new("docker")
+            .args(&args)
+            .output()
+            .map_err(|_| Error::DockerCommandFailed)?;
+
+        if output.status.success() {
+            let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            Ok(container_id)
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            Err(Error::Unexpected(stderr.trim().to_string()))
+        }
+    }
+
+    fn start(&self, name: &str) -> Result<(), Error> {
+        let output = Command::new("docker")
+            .args(["start", name])
+            .output()
+            .map_err(|_| Error::DockerCommandFailed)?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+            if stderr.contains("no such container") {
+                Err(Error::ContainerNotFound)
+            } else {
+                Err(Error::Unexpected(stderr.trim().to_string()))
+            }
+        }
+    }
+
+    fn stop(&self, name: &str) -> Result<(), Error> {
+        let output = Command::new("docker")
+            .args(["stop", name])
+            .output()
+            .map_err(|_| Error::DockerCommandFailed)?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+            if stderr.contains("no such container") {
+                Err(Error::ContainerNotFound)
+            } else {
+                Err(Error::Unexpected(stderr.trim().to_string()))
+            }
+        }
+    }
+
+    fn inspect(&self, name: &str) -> Result<String, Error> {
+        let output = Command::new("docker")
+            .args(["inspect", name])
+            .output()
+            .map_err(|_| Error::DockerCommandFailed)?;
+
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+            if stderr.contains("no such container") {
+                Err(Error::ContainerNotFound)
+            } else {
+                Err(Error::Unexpected(stderr.trim().to_string()))
+            }
+        }
+    }
+}

--- a/daemon/src/services/mod.rs
+++ b/daemon/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod docker;

--- a/daemon/tests/apps_delete.rs
+++ b/daemon/tests/apps_delete.rs
@@ -4,7 +4,8 @@ use axum::{
 };
 use lightshuttle_core::{
     api::routes::router,
-    docker::{create_and_run_container, remove_container, ContainerConfig},
+    docker::{remove_container, ContainerConfig},
+    services::docker::{DockerClient, ShellDockerClient},
 };
 use tower::ServiceExt;
 
@@ -29,7 +30,8 @@ async fn delete_existing_app_should_succeed() {
         restart_policy: None,
     };
 
-    create_and_run_container(config).expect("Failed to launch container");
+    let docker = ShellDockerClient;
+    docker.run(config).expect("Failed to launch container");
 
     let app = router();
     let response = app

--- a/daemon/tests/apps_get.rs
+++ b/daemon/tests/apps_get.rs
@@ -5,7 +5,8 @@ use axum::{
 use http_body_util::BodyExt;
 use lightshuttle_core::{
     api::routes::router,
-    docker::{create_and_run_container, remove_container, ContainerConfig},
+    docker::{remove_container, ContainerConfig},
+    services::docker::{DockerClient, ShellDockerClient},
 };
 use serde_json::Value;
 use tower::ServiceExt;
@@ -69,7 +70,8 @@ async fn apps_search_filter_should_return_matching_container() {
         restart_policy: None,
     };
 
-    create_and_run_container(config).expect("Failed to create container");
+    let docker = ShellDockerClient;
+    docker.run(config).expect("Failed to create container");
 
     let app = router();
     let response = app
@@ -137,7 +139,8 @@ async fn get_existing_app_should_succeed() {
         restart_policy: None,
     };
 
-    create_and_run_container(config).expect("Failed to create container");
+    let docker = ShellDockerClient;
+    docker.run(config).expect("Failed to create container");
     let app = router();
     let response = app
         .oneshot(
@@ -208,7 +211,8 @@ async fn get_logs_should_succeed() {
         restart_policy: None,
     };
 
-    create_and_run_container(config).expect("Failed to create container");
+    let docker = ShellDockerClient;
+    docker.run(config).expect("Failed to create container");
 
     let app = router();
     let response = app
@@ -255,7 +259,8 @@ async fn get_app_status_should_return_running() {
         restart_policy: None,
     };
 
-    create_and_run_container(config).expect("Failed to create container");
+    let docker = ShellDockerClient;
+    docker.run(config).expect("Failed to create container");
 
     let app = router();
 

--- a/daemon/tests/apps_post.rs
+++ b/daemon/tests/apps_post.rs
@@ -6,7 +6,8 @@ use axum::{
 use http_body_util::BodyExt;
 use lightshuttle_core::{
     api::routes::router,
-    docker::{create_and_run_container, remove_container, ContainerConfig},
+    docker::{remove_container, ContainerConfig},
+    services::docker::{DockerClient, ShellDockerClient},
 };
 use serde_json::{json, Value};
 use tower::ServiceExt;
@@ -227,7 +228,8 @@ async fn post_apps_name_recreate_should_restart_container() {
         restart_policy: None,
     };
 
-    create_and_run_container(config).expect("Failed to create container");
+    let docker = ShellDockerClient;
+    docker.run(config).expect("Failed to create container");
 
     let app = router();
     let response = app

--- a/daemon/tests/docker.rs
+++ b/daemon/tests/docker.rs
@@ -1,6 +1,9 @@
 use std::env;
 
-use lightshuttle_core::docker::{create_and_run_container, ContainerConfig};
+use lightshuttle_core::{
+    docker::ContainerConfig,
+    services::docker::{DockerClient, ShellDockerClient},
+};
 
 #[tokio::test]
 async fn test_launch_container_via_cli() {
@@ -20,7 +23,8 @@ async fn test_launch_container_via_cli() {
         restart_policy: None,
     };
 
-    match create_and_run_container(config) {
+    let docker = ShellDockerClient;
+    match docker.run(config) {
         Ok(container_id) => {
             println!("✅ Launched container: {container_id}");
             assert!(!container_id.is_empty());

--- a/daemon/tests/utils.rs
+++ b/daemon/tests/utils.rs
@@ -1,6 +1,0 @@
-use axum::Router;
-use lightshuttle_core::api::routes::router;
-
-pub fn test_app() -> Router {
-    router()
-}


### PR DESCRIPTION
## Summary
- introduce DockerClient trait with ShellDockerClient CLI implementation
- inject Docker client state into router and handlers
- refactor container helpers and tests to use trait

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689df747762c8321836093364b4d14d9