### PR TITLE
feat: document API with OpenAPI and Swagger UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - 🌐 CORS origins configurable via `ALLOWED_ORIGINS` env var; disallowed origins return `403`
 - 📝 Documented changelog tracking and feature flag usage in `AGENT.md`
+- 📘 OpenAPI docs and Swagger UI covering Apps, Health, Metrics and Version endpoints
 
 ## [0.3.0] – 2025-08-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,7 +43,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -104,8 +113,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -123,10 +138,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
+name = "bumpalo"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -175,6 +190,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,24 +211,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
+name = "displaydoc"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.60.2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -277,17 +293,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -384,6 +389,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,16 +536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
-name = "libredox"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
 name = "lightshuttle-cli"
 version = "0.3.0"
 
@@ -458,6 +560,12 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
@@ -519,7 +627,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -546,12 +654,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "overload"
@@ -582,7 +684,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -598,27 +700,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "potential_utf"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "zerovec",
 ]
 
 [[package]]
@@ -637,17 +724,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -714,8 +790,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "shellexpand",
- "syn 2.0.104",
+ "syn",
  "walkdir",
 ]
 
@@ -773,7 +848,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -786,6 +861,19 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
 ]
 
 [[package]]
@@ -831,15 +919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
-dependencies = [
- "dirs",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +926,12 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
@@ -867,18 +952,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.109"
+name = "stable_deref_trait"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "unicode-ident",
-]
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
@@ -896,6 +977,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thiserror"
@@ -923,7 +1015,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -934,7 +1026,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -944,6 +1036,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -961,7 +1063,7 @@ dependencies = [
  "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -972,7 +1074,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1054,7 +1156,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1115,40 +1217,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "utoipa"
-version = "4.2.3"
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
  "indexmap",
  "serde",
  "serde_json",
+ "serde_norway",
  "utoipa-gen",
 ]
 
 [[package]]
 name = "utoipa-gen"
-version = "4.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "4.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154517adf0d0b6e22e8e1f385628f14fcaa3db43531dc74303d3edef89d6dfe5"
+checksum = "db4b5ac679cc6dfc5ea3f2823b0291c777750ffd5e13b21137e0f7ac0e8f9617"
 dependencies = [
+ "axum",
+ "base64",
  "mime_guess",
  "regex",
  "rust-embed",
  "serde",
  "serde_json",
+ "url",
  "utoipa",
  "zip",
 ]
@@ -1203,7 +1331,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1213,27 +1341,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1242,31 +1355,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1276,22 +1372,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1300,22 +1384,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1324,22 +1396,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1348,31 +1408,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
+name = "writeable"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
- "byteorder",
+ "arbitrary",
  "crc32fast",
  "crossbeam-utils",
+ "displaydoc",
  "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.12",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -15,8 +15,8 @@ axum = "0.7"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "signal", "time", "net"] }
 
 # Documentation
-utoipa = "4"
-utoipa-swagger-ui = "4"
+utoipa = { version = "5", features = ["yaml"] }
+utoipa-swagger-ui = { version = "8", features = ["axum"] }
 
 # Error handling
 thiserror = "1.0"

--- a/daemon/src/api/routes.rs
+++ b/daemon/src/api/routes.rs
@@ -8,6 +8,7 @@ use axum::{
 use std::{convert::Infallible, env, sync::Arc};
 use tower_http::cors::{Any, CorsLayer};
 
+use crate::openapi::ApiDoc;
 use crate::routes::{
     apps::{
         create_app, delete_app, get_app, get_app_logs, get_app_status, list_apps, recreate_app,
@@ -16,6 +17,8 @@ use crate::routes::{
     health, metrics, version,
 };
 use crate::services::docker::{DockerClient, ShellDockerClient};
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
 
 /// Builds the API router mounted at `/api/v1`.
 pub fn router() -> Router {
@@ -78,5 +81,10 @@ pub fn router() -> Router {
         api
     };
 
-    Router::new().nest("/api/v1", api).with_state(docker)
+    let swagger = SwaggerUi::new("/swagger-ui").url("/api-doc/openapi.json", ApiDoc::openapi());
+
+    Router::new()
+        .nest("/api/v1", api)
+        .merge(swagger)
+        .with_state(docker)
 }

--- a/daemon/src/bin/openapi_export.rs
+++ b/daemon/src/bin/openapi_export.rs
@@ -1,0 +1,13 @@
+use std::{error::Error, fs, path::Path};
+
+use lightshuttle_core::openapi::ApiDoc;
+use utoipa::OpenApi;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let doc = ApiDoc::openapi();
+    let yaml = doc.to_yaml()?;
+    let out_dir = Path::new("openapi");
+    fs::create_dir_all(out_dir)?;
+    fs::write(out_dir.join("openapi.yaml"), yaml)?;
+    Ok(())
+}

--- a/daemon/src/docker/models.rs
+++ b/daemon/src/docker/models.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// Container creation parameters
 pub struct ContainerConfig<'a> {
@@ -15,7 +16,7 @@ pub struct ContainerConfig<'a> {
 }
 
 /// Represents an application instance (a running Docker container).
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, ToSchema)]
 pub struct AppInstance {
     pub id: u32,
     pub name: String,
@@ -26,7 +27,7 @@ pub struct AppInstance {
 }
 
 /// Represents the status of an application.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum AppStatus {
     Running,

--- a/daemon/src/errors.rs
+++ b/daemon/src/errors.rs
@@ -1,6 +1,8 @@
 use axum::response::{IntoResponse, Response};
 use axum::{http::StatusCode, Json};
+use serde::Serialize;
 use thiserror::Error;
+use utoipa::ToSchema;
 
 /// Defines all the possible errors for the LightShuttle daemon service.
 #[derive(Error, Debug)]
@@ -24,6 +26,12 @@ pub enum Error {
     BadRequest(String),
 }
 
+/// Standard error response body.
+#[derive(Serialize, ToSchema)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let status = match self {
@@ -34,9 +42,9 @@ impl IntoResponse for Error {
             Error::InvalidRequest(_) => StatusCode::BAD_REQUEST,
             Error::BadRequest(_) => StatusCode::BAD_REQUEST,
         };
-        let body = Json(serde_json::json!({
-            "error": self.to_string(),
-        }));
+        let body = Json(ErrorResponse {
+            error: self.to_string(),
+        });
 
         (status, body).into_response()
     }

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod docker;
 pub mod errors;
+pub mod openapi;
 pub mod routes;
 pub mod services;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,6 +1,7 @@
 mod api;
 mod docker;
 mod errors;
+mod openapi;
 mod routes;
 mod services;
 

--- a/daemon/src/openapi.rs
+++ b/daemon/src/openapi.rs
@@ -1,0 +1,56 @@
+use utoipa::OpenApi;
+
+use crate::{
+    docker::models::{AppInstance, AppStatus},
+    errors::ErrorResponse,
+    routes::{
+        apps,
+        health::{self, HealthResponse},
+        metrics::{self, MetricsResponse},
+        models::{
+            AppListResponse, ContainerIdResponse, CreateAppRequest, CreateAppResponse, Pagination,
+            StatusResponse,
+        },
+        version::{self, VersionResponse},
+    },
+};
+
+/// OpenAPI documentation for LightShuttle API.
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        apps::create_app,
+        apps::start_app,
+        apps::stop_app,
+        apps::recreate_app,
+        apps::list_apps,
+        apps::get_app,
+        apps::get_app_logs,
+        apps::get_app_status,
+        apps::delete_app,
+        health::health,
+        metrics::metrics,
+        version::version,
+    ),
+    components(schemas(
+        CreateAppRequest,
+        Pagination,
+        AppListResponse,
+        CreateAppResponse,
+        ContainerIdResponse,
+        StatusResponse,
+        HealthResponse,
+        MetricsResponse,
+        VersionResponse,
+        AppInstance,
+        AppStatus,
+        ErrorResponse,
+    )),
+    tags(
+        (name = "Apps", description = "Application management"),
+        (name = "Health", description = "Health check"),
+        (name = "Metrics", description = "Service metrics"),
+        (name = "Version", description = "Service version"),
+    )
+)]
+pub struct ApiDoc;

--- a/daemon/src/routes/health.rs
+++ b/daemon/src/routes/health.rs
@@ -1,11 +1,18 @@
 use axum::Json;
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct HealthResponse {
     status: &'static str,
 }
 
+#[utoipa::path(
+    get,
+    path = "/health",
+    tag = "Health",
+    responses((status = 200, description = "API health status", body = HealthResponse))
+)]
 pub async fn health() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
 }

--- a/daemon/src/routes/metrics.rs
+++ b/daemon/src/routes/metrics.rs
@@ -1,12 +1,19 @@
 use axum::Json;
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct MetricsResponse {
     uptime: &'static str,
     requests_handled: u32,
 }
 
+#[utoipa::path(
+    get,
+    path = "/metrics",
+    tag = "Metrics",
+    responses((status = 200, description = "Service metrics", body = MetricsResponse))
+)]
 pub async fn metrics() -> Json<MetricsResponse> {
     Json(MetricsResponse {
         uptime: "42s",

--- a/daemon/src/routes/models.rs
+++ b/daemon/src/routes/models.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
+use crate::docker::models::AppInstance;
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
 /// Request payload for creating a new application/container.
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 pub struct CreateAppRequest {
     pub name: String,
     pub image: String,
@@ -16,7 +18,7 @@ pub struct CreateAppRequest {
 }
 
 /// Pagination parameters for listing applications.
-#[derive(Deserialize)]
+#[derive(Deserialize, IntoParams, ToSchema)]
 pub struct Pagination {
     pub page: Option<usize>,
     pub limit: Option<usize>,
@@ -24,10 +26,29 @@ pub struct Pagination {
 }
 
 /// Standard response format for paginated lists.
-#[derive(Serialize)]
-pub struct PaginatedResponse<T> {
+#[derive(Serialize, ToSchema)]
+pub struct AppListResponse {
     pub total: usize,
     pub page: usize,
     pub limit: usize,
-    pub items: Vec<T>,
+    pub items: Vec<AppInstance>,
+}
+
+/// Response body returned when creating a new application.
+#[derive(Serialize, ToSchema)]
+pub struct CreateAppResponse {
+    pub status: String,
+    pub container_id: String,
+}
+
+/// Response containing only a container identifier.
+#[derive(Serialize, ToSchema)]
+pub struct ContainerIdResponse {
+    pub container_id: String,
+}
+
+/// Generic status response body.
+#[derive(Serialize, ToSchema)]
+pub struct StatusResponse {
+    pub status: String,
 }

--- a/daemon/src/routes/version.rs
+++ b/daemon/src/routes/version.rs
@@ -1,11 +1,18 @@
 use axum::Json;
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct VersionResponse {
     version: &'static str,
 }
 
+#[utoipa::path(
+    get,
+    path = "/version",
+    tag = "Version",
+    responses((status = 200, description = "Service version", body = VersionResponse))
+)]
 pub async fn version() -> Json<VersionResponse> {
     Json(VersionResponse {
         version: env!("CARGO_PKG_VERSION"),

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,582 @@
+openapi: 3.1.0
+info:
+  title: lightshuttle_core
+  description: ''
+  license:
+    name: ''
+  version: 0.3.0
+paths:
+  /apps:
+    get:
+      tags:
+      - Apps
+      summary: Handles GET /apps
+      description: |-
+        Lists running containers, paginated.
+
+        # Arguments
+        - `pagination`: Query parameters `page` and `limit`.
+
+        # Returns
+        - `200 OK` with paginated list of applications.
+        - `200 OK` with an empty list if Docker is unavailable.
+        - `500 Internal Server Error` on unexpected errors.
+      operationId: list_apps
+      parameters:
+      - name: page
+        in: path
+        required: true
+        schema:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+      - name: limit
+        in: path
+        required: true
+        schema:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+      - name: search
+        in: path
+        required: true
+        schema:
+          type:
+          - string
+          - 'null'
+      responses:
+        '200':
+          description: List running apps
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppListResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+      - Apps
+      summary: Handles POST /apps
+      description: |-
+        Launches a new container based on the provided configuration.
+
+        # Arguments
+        - `payload`: JSON body containing app creation parameters.
+
+        # Returns
+        - `201 Created` with container ID if successful.
+        - `400 Bad Request` with error message if failed.
+      operationId: create_app
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAppRequest'
+        required: true
+      responses:
+        '201':
+          description: App created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateAppResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /apps/{name}:
+    get:
+      tags:
+      - Apps
+      summary: Retrieve a specific running app by its container name.
+      description: |-
+        # Path Parameters
+        - `name`: The Docker container name.
+
+        # Returns
+        - `200 OK` with app details if found
+        - `404 Not Found` if the app does not exist
+        - `500 Internal Server Error` if Docker command fails
+      operationId: get_app
+      parameters:
+      - name: name
+        in: path
+        description: Container name
+        required: true
+      responses:
+        '200':
+          description: App details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppInstance'
+        '404':
+          description: App not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+      - Apps
+      summary: Deletes an application/container by its name.
+      description: |-
+        # Arguments
+        - `name`: The container name to delete.
+
+        # Returns
+        - `204 No Content` if deleted successfully
+        - `404 Not Found` if container doesn't exist
+        - `500 Internal Server Error` if something went wrong
+      operationId: delete_app
+      parameters:
+      - name: name
+        in: path
+        description: Container name
+        required: true
+      responses:
+        '204':
+          description: App deleted
+        '404':
+          description: App not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /apps/{name}/logs:
+    get:
+      tags:
+      - Apps
+      summary: Retrieve the logs of a running container.
+      description: |-
+        # Path Parameters
+        - `name`: The Docker container name.
+
+        # Returns
+        - `200 OK` with the logs as plain text.
+        - `404 Not Found` if the container does not exist.
+        - `500 Internal Server Error` if fetching logs fails.
+      operationId: get_app_logs
+      parameters:
+      - name: name
+        in: path
+        description: Container name
+        required: true
+      responses:
+        '200':
+          description: Container logs
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: App not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /apps/{name}/recreate:
+    post:
+      tags:
+      - Apps
+      summary: Handles POST /apps/:name/recreate
+      description: |-
+        Recreates a container using its original config (image, ports, labels).
+
+        # Returns
+        - `200 OK` with new container ID
+        - `404 Not Found` if container doesn't exist
+        - `500 Internal Server Error` otherwise
+      operationId: recreate_app
+      parameters:
+      - name: name
+        in: path
+        description: Container name
+        required: true
+      responses:
+        '200':
+          description: App recreated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContainerIdResponse'
+        '404':
+          description: App not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /apps/{name}/start:
+    post:
+      tags:
+      - Apps
+      summary: Handles POST /apps/:name/start
+      description: |-
+        Starts an existing container by name.
+
+        # Returns
+        - `200 OK` if the container was started
+        - `404 Not Found` if the container doesn't exist
+        - `500 Internal Server Error` otherwise
+      operationId: start_app
+      parameters:
+      - name: name
+        in: path
+        description: Container name
+        required: true
+      responses:
+        '200':
+          description: App started
+        '404':
+          description: App not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /apps/{name}/status:
+    get:
+      tags:
+      - Apps
+      summary: Handles GET /apps/:name/status
+      description: |-
+        Returns the status of a container (`running`, `exited`, etc.)
+
+        # Returns
+        - `200 OK` with JSON { status }
+        - `404 Not Found` if the container doesn't exist
+        - `500 Internal Server Error` on error
+      operationId: get_app_status
+      parameters:
+      - name: name
+        in: path
+        description: Container name
+        required: true
+      responses:
+        '200':
+          description: App status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '404':
+          description: App not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /apps/{name}/stop:
+    post:
+      tags:
+      - Apps
+      summary: Handles POST /apps/:name/stop
+      description: |-
+        Stops a running container by name.
+
+        # Returns
+        - `200 OK` if the container was stopped
+        - `404 Not Found` if the container doesn't exist
+        - `500 Internal Server Error` otherwise
+      operationId: stop_app
+      parameters:
+      - name: name
+        in: path
+        description: Container name
+        required: true
+      responses:
+        '200':
+          description: App stopped
+        '404':
+          description: App not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /health:
+    get:
+      tags:
+      - Health
+      operationId: health
+      responses:
+        '200':
+          description: API health status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+  /metrics:
+    get:
+      tags:
+      - Metrics
+      operationId: metrics
+      responses:
+        '200':
+          description: Service metrics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsResponse'
+  /version:
+    get:
+      tags:
+      - Version
+      operationId: version
+      responses:
+        '200':
+          description: Service version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionResponse'
+components:
+  schemas:
+    AppInstance:
+      type: object
+      description: Represents an application instance (a running Docker container).
+      required:
+      - id
+      - name
+      - status
+      - image
+      - ports
+      - created_at
+      properties:
+        created_at:
+          type: string
+        id:
+          type: integer
+          format: int32
+          minimum: 0
+        image:
+          type: string
+        name:
+          type: string
+        ports:
+          type: array
+          items:
+            type: integer
+            format: int32
+            minimum: 0
+        status:
+          $ref: '#/components/schemas/AppStatus'
+    AppListResponse:
+      type: object
+      description: Standard response format for paginated lists.
+      required:
+      - total
+      - page
+      - limit
+      - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppInstance'
+        limit:
+          type: integer
+          minimum: 0
+        page:
+          type: integer
+          minimum: 0
+        total:
+          type: integer
+          minimum: 0
+    AppStatus:
+      type: string
+      description: Represents the status of an application.
+      enum:
+      - running
+      - stopped
+      - error
+    ContainerIdResponse:
+      type: object
+      description: Response containing only a container identifier.
+      required:
+      - container_id
+      properties:
+        container_id:
+          type: string
+    CreateAppRequest:
+      type: object
+      description: Request payload for creating a new application/container.
+      required:
+      - name
+      - image
+      - ports
+      - container_port
+      properties:
+        container_port:
+          type: integer
+          format: int32
+          minimum: 0
+        env:
+          type:
+          - object
+          - 'null'
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
+        image:
+          type: string
+        labels:
+          type:
+          - object
+          - 'null'
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
+        name:
+          type: string
+        ports:
+          type: array
+          items:
+            type: integer
+            format: int32
+            minimum: 0
+        restart_policy:
+          type:
+          - string
+          - 'null'
+        volumes:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+    CreateAppResponse:
+      type: object
+      description: Response body returned when creating a new application.
+      required:
+      - status
+      - container_id
+      properties:
+        container_id:
+          type: string
+        status:
+          type: string
+    ErrorResponse:
+      type: object
+      description: Standard error response body.
+      required:
+      - error
+      properties:
+        error:
+          type: string
+    HealthResponse:
+      type: object
+      required:
+      - status
+      properties:
+        status:
+          type: string
+    MetricsResponse:
+      type: object
+      required:
+      - uptime
+      - requests_handled
+      properties:
+        requests_handled:
+          type: integer
+          format: int32
+          minimum: 0
+        uptime:
+          type: string
+    Pagination:
+      type: object
+      description: Pagination parameters for listing applications.
+      properties:
+        limit:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+        page:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+        search:
+          type:
+          - string
+          - 'null'
+    StatusResponse:
+      type: object
+      description: Generic status response body.
+      required:
+      - status
+      properties:
+        status:
+          type: string
+    VersionResponse:
+      type: object
+      required:
+      - version
+      properties:
+        version:
+          type: string
+tags:
+- name: Apps
+  description: Application management
+- name: Health
+  description: Health check
+- name: Metrics
+  description: Service metrics
+- name: Version
+  description: Service version


### PR DESCRIPTION
## Summary
- document Apps, Health, Metrics, and Version routes with utoipa
- serve generated spec via `/swagger-ui`
- add `openapi_export` binary to emit `openapi/openapi.yaml`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo run --bin openapi_export`


------
https://chatgpt.com/codex/tasks/task_e_689e10068f0c832194b71ab431bca5c7