### PR TITLE
Harden Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - 🛡️ Swagger UI and OpenAPI routes gated behind the `openapi` feature and disabled in release builds
 - 🚫 Daemon and CLI exit if executed as root
+- 🗜️ Docker image now uses a distroless base and removes build-time tools to reduce attack surface
 
 ## [0.3.0] – 2025-08-02
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,37 @@
-    FROM rust:1.86-slim AS builder
+FROM rust:1.86-slim AS builder
 
-    WORKDIR /app
-    COPY . .
-    RUN cargo build --release --manifest-path daemon/Cargo.toml
-    
-    FROM debian:stable-slim AS dockercli
-    WORKDIR /docker
+WORKDIR /app
+COPY . .
+RUN cargo build --locked --release --manifest-path daemon/Cargo.toml
 
-    RUN apt-get update \
-        && apt-get install -y --no-install-recommends curl ca-certificates \
-        && rm -rf /var/lib/apt/lists/*
+FROM debian:stable-slim AS dockercli
+WORKDIR /docker
 
-    ARG DOCKER_VERSION=25.0.3
-    ARG DOCKER_SHA256=fa56a890c16ca83715d7e62b351ff0528fcb92f70100129caf6382a8945b95fb
-    RUN set -eux; \
-        curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz; \
-        echo "${DOCKER_SHA256}  docker.tgz" | sha256sum -c -; \
-        tar -xzf docker.tgz; \
-        mv docker/docker /usr/bin/docker; \
-        chmod +x /usr/bin/docker; \
-        rm -r docker docker.tgz
-    
-    FROM debian:stable-slim
-    
-    WORKDIR /app
-    
-    COPY --from=builder /app/target/release/lightshuttle_core /usr/local/bin/lightshuttle
-    COPY --from=dockercli /usr/bin/docker /usr/local/bin/docker
-    COPY seccomp-profile.json /seccomp.json
-    
-    RUN useradd -m -u 1000 lightshuttle
-    USER lightshuttle
-    
-    ENV BIND_ADDRESS=0.0.0.0:7878
-    EXPOSE 7878
+ARG DOCKER_VERSION=25.0.3
+ARG DOCKER_SHA256=fa56a890c16ca83715d7e62b351ff0528fcb92f70100129caf6382a8945b95fb
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+    && echo "${DOCKER_SHA256}  docker.tgz" | sha256sum -c - \
+    && tar -xzf docker.tgz \
+    && mv docker/docker /usr/bin/docker \
+    && chmod +x /usr/bin/docker \
+    && rm -r docker docker.tgz \
+    && apt-get purge -y --auto-remove curl \
+    && rm -rf /var/lib/apt/lists/*
 
-    CMD ["lightshuttle"]
+FROM gcr.io/distroless/cc-debian12:nonroot
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/lightshuttle_core /usr/local/bin/lightshuttle
+COPY --from=dockercli /usr/bin/docker /usr/local/bin/docker
+COPY seccomp-profile.json /seccomp.json
+
+USER nonroot
+
+ENV BIND_ADDRESS=0.0.0.0:7878
+EXPOSE 7878
+
+CMD ["lightshuttle"]
     


### PR DESCRIPTION
## Summary
- use distroless base image for minimal runtime
- purge build-time packages and lock cargo build

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689fb72ec45083218b60b259bc73badd