### PR TITLE
ci: add sbom and provenance attestation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,3 +45,5 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          sbom: true
+          provenance: mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🌐 `DOCKER_HOST` env var for proxy configuration
 - 🛡️ Default seccomp profile embedded in Docker image and applied to containers
 - 📚 Proxy usage documented in `docs/SECURITY.md`
+- 🧾 Docker publish workflow attaches SBOM and provenance attestations
 
 ### Changed
 - ⬆️ Updated Docker CLI to version 28.3.3 to include Go stdlib patches addressing CVE-2024-24790


### PR DESCRIPTION
## Summary
- attach SBOM and SLSA provenance to Docker image workflow
- note workflow change in changelog

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a086062a5c8321985f37ac6c172023